### PR TITLE
util.js: Allow remote host to be specified.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,7 @@ var config = app.config;
 module.exports.config = {
   adapter   : config.get("adapter"),
   db        : config.get("db"),
+  host      : config.get("host")||'127.0.0.1',
   user      : config.get("user"),
   password  : config.get("password")
 };


### PR DESCRIPTION
Although I could do "pdns config set host FOO", I couldn't get pdns to connect to the remote server until I added this line.