### PR TITLE
Connection close function is implemented

### DIFF
--- a/lib/adapter/mysql.js
+++ b/lib/adapter/mysql.js
@@ -17,6 +17,12 @@ var adapter = module.exports = {
       createTablesIfNotExist(config, callback);
     });
   },
+  
+  end: function(callback) {
+	client.end(function(err) {
+	    callback(err);
+	});
+  },
 
   domains: {
     

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,10 @@ module.exports = function(config) {
       remove: auto(function(domain, record, options, callback) {
         adapter.records.remove(domain, record, callback);
       })
-    }
+    },
+    end: auto(function(callback) {
+        adapter.end(callback);
+    })
   }
 }
 


### PR DESCRIPTION
This software does not  currently contain a connection close function, so that the service using node-pdns sometimes returns error that too many connections are established with mysql. As my change enables users to close the connection by themselves, it could avoid making many connections. Thank you.
